### PR TITLE
Avoid PHP Notice: Undefined offset

### DIFF
--- a/core/class/mqtt2.class.php
+++ b/core/class/mqtt2.class.php
@@ -464,7 +464,7 @@ class mqtt2 extends eqLogic {
          $infos['port'] = config::byKey('remote::port', __CLASS__);
       }
       $infos['user'] = $authentifications[0];
-      $infos['password'] = $authentifications[1];
+      $infos['password'] = $authentifications[1] ?? null;
       return $infos;
    }
 


### PR DESCRIPTION
Displayed when password is empty:
"PHP Notice:  Undefined offset: 1 in /var/www/html/plugins/mqtt2/core/class/mqtt2.class.php on line 467"